### PR TITLE
feat(users): define users domain model (no auth)

### DIFF
--- a/src/areas/entities/area.entity.ts
+++ b/src/areas/entities/area.entity.ts
@@ -1,1 +1,13 @@
-export class Area {}
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('areas')
+export class Area {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  name: string; // FINANZAS, SOPORTE, CALIDAD, etc
+
+  @Column({ nullable: true })
+  description?: string;
+}

--- a/src/usuarios/entities/usuario.entity.ts
+++ b/src/usuarios/entities/usuario.entity.ts
@@ -1,1 +1,51 @@
-export class Usuario {}
+import { Area } from "src/areas/entities/area.entity";
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, UpdateDateColumn } from "typeorm";
+import { UserStatus } from "../enums/user-status.enum";
+import { Role } from "../roles/entities/role.entity";
+
+@Entity('usuarios')
+export class Usuario {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({
+    type: 'uuid',
+    default: () => 'gen_random_uuid()',
+    unique: true,
+  })
+  publicId: string;
+
+  @Column({ nullable: true, unique: true })
+  rut?: string;
+
+  @Column()
+  firstName: string;
+
+  @Column()
+  lastName: string;
+
+  @Column({ unique: true })
+  email: string;
+
+  @Column({ nullable: true, select: false })
+  passwordHash?: string; // preparado, no usado aún
+
+  @ManyToOne(() => Role, { eager: true })
+  role: Role;
+
+  @ManyToOne(() => Area, { eager: true })
+  area: Area;
+
+  @Column({
+    type: 'enum',
+    enum: UserStatus,
+    default: UserStatus.ACTIVE,
+  })
+  status: UserStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/usuarios/enums/user-status.enum.ts
+++ b/src/usuarios/enums/user-status.enum.ts
@@ -1,0 +1,4 @@
+export enum UserStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+}

--- a/src/usuarios/roles/entities/role.entity.ts
+++ b/src/usuarios/roles/entities/role.entity.ts
@@ -1,1 +1,13 @@
-export class Role {}
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('roles')
+export class Role {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  name: string; // ADMIN, SUPERVISOR, ANALYST
+
+  @Column({ nullable: true })
+  description?: string;
+}

--- a/src/usuarios/usuarios.module.ts
+++ b/src/usuarios/usuarios.module.ts
@@ -2,10 +2,16 @@ import { Module } from '@nestjs/common';
 import { UsuariosService } from './usuarios.service';
 import { UsuariosController } from './usuarios.controller';
 import { RolesModule } from './roles/roles.module';
-
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Usuario } from './entities/usuario.entity';
+import { Area } from 'src/areas/entities/area.entity';
+import { Role } from './roles/entities/role.entity';
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([Usuario, Role, Area]),
+    RolesModule,
+  ],
   controllers: [UsuariosController],
   providers: [UsuariosService],
-  imports: [RolesModule],
 })
 export class UsuariosModule {}


### PR DESCRIPTION
## Summary
Defines the Users domain model following a domain-first approach.

## What was done
- Added `Usuario` entity with:
  - Internal numeric PK
  - Public UUID for API exposure
  - Optional RUT (Chile context)
  - Optional passwordHash (prepared for future auth)
  - Status enum (ACTIVE / INACTIVE)
  - Timestamps
- Modeled `Role` as a dedicated entity (not enum)
- Modeled `Area` as an organizational entity
- Established proper relations between User → Role → Area
- Registered entities with TypeORM for persistence

## Out of scope (by design)
- Authentication / Login
- JWT / Guards
- Permissions enforcement
- Business logic and API endpoints

This PR focuses strictly on clean domain modeling.
Refs #7
